### PR TITLE
Adds a new handler on the Go service

### DIFF
--- a/gcs-authenticator/README.md
+++ b/gcs-authenticator/README.md
@@ -38,3 +38,17 @@ $ sudo service gcsauth stop
 $ sudo service gcsauth status
 $ sudo systemctl enable gcsauth.service
 ```
+
+# Allow a docker container to access localhost
+
+The docker container must use the address from:
+
+```sh
+ip addr show docker0
+```
+
+Additionally, do not forget to update the firewall:
+
+```sh
+sudo ufw allow from 192.168.0.1/16 to any port 9990
+```

--- a/gcs-authenticator/mod.go
+++ b/gcs-authenticator/mod.go
@@ -65,7 +65,7 @@ func main() {
 		logger.Fatalf("please set %s", BUCKET_KEY_NAME)
 	}
 
-	jsonKey, err := ioutil.ReadFile(os.Getenv(GCS_KEY_PATH))
+	jsonKey, err := ioutil.ReadFile(gcs_key_path)
 	if err != nil {
 		logger.Fatalf("failed to read key: %v", err.Error())
 	}
@@ -75,7 +75,7 @@ func main() {
 		logger.Fatalf("failed to read config: %v", err.Error())
 	}
 
-	client, err := storage.NewClient(context.Background(), option.WithCredentialsFile(os.Getenv("GCS_PRIVATE_PATH")))
+	client, err := storage.NewClient(context.Background(), option.WithCredentialsFile(gcs_key_path))
 	if err != nil {
 		logger.Fatalf("failed to creat client: %v", err)
 	}


### PR DESCRIPTION
Adds a new handler that responds to a directus hook. This new handler updates a Google Cloud Storage object's ACL to make it public. We need it to store public images on the GCS storage, which is private by default.