### PR TITLE
Removes problematic field from the hook

### DIFF
--- a/gcs-authenticator/go.mod
+++ b/gcs-authenticator/go.mod
@@ -5,5 +5,6 @@ go 1.14
 require (
 	cloud.google.com/go/storage v1.14.0
 	golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/api v0.40.0
 )

--- a/gcs-authenticator/mod.go
+++ b/gcs-authenticator/mod.go
@@ -279,7 +279,6 @@ func gcspub(client *storage.Client, bucket string) func(http.ResponseWriter, *ht
 			Event          string          `json:"event"`
 			Accountability accountability  `json:"accountability"`
 			Payload        json.RawMessage `json:"payload"`
-			Keys           []string        `json:"keys"`
 			Collection     string          `json:"collection"`
 		}
 
@@ -287,7 +286,9 @@ func gcspub(client *storage.Client, bucket string) func(http.ResponseWriter, *ht
 
 		err := json.NewDecoder(r.Body).Decode(&h)
 		if err != nil {
-			http.Error(w, "failed to unmarshal hook: "+err.Error(), http.StatusBadRequest)
+			err = xerrors.Errorf("failed to unmarshal hook: %v", err)
+			fmt.Println("error:", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
@@ -299,7 +300,9 @@ func gcspub(client *storage.Client, bucket string) func(http.ResponseWriter, *ht
 
 		err = json.Unmarshal(h.Payload, &m)
 		if err != nil {
-			http.Error(w, "failed to unmarshal image"+err.Error(), http.StatusBadRequest)
+			err = xerrors.Errorf("failed to unmarshal image: %v", err)
+			fmt.Println("error:", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
@@ -310,7 +313,9 @@ func gcspub(client *storage.Client, bucket string) func(http.ResponseWriter, *ht
 
 		filenameDisk, err := getDirectusFilename(object)
 		if err != nil {
-			http.Error(w, "failed to get filename_disk: "+err.Error(), http.StatusInternalServerError)
+			err = xerrors.Errorf("failed to get filename_disk: %v", err.Error())
+			fmt.Println("error:", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
@@ -321,7 +326,9 @@ func gcspub(client *storage.Client, bucket string) func(http.ResponseWriter, *ht
 
 		err = acl.Set(ctx, storage.AllUsers, storage.RoleReader)
 		if err != nil {
-			http.Error(w, "failed to set acl: "+err.Error(), http.StatusInternalServerError)
+			err = xerrors.Errorf("failed to set acl: %v", err)
+			fmt.Println("error:", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 	}


### PR DESCRIPTION
The `keys` field can be an array of string or int depending on the type of collection. Also adds some logging.