### PR TITLE
Secures the GCS endpoints

### DIFF
--- a/.github/workflows/deploy-bullenetwork-ch.yml
+++ b/.github/workflows/deploy-bullenetwork-ch.yml
@@ -25,10 +25,9 @@ jobs:
     - name: Build
       run: |
         cd bullenetwork.ch
-        echo "GCS_PROXY=${{secrets.BULLENETWORK_CH_GCS_PROXY}}" >> .env.production
-        echo "GCS_PROXY_ARCHIVE=${{secrets.BULLENETWORK_CH_GCS_PROXY_ARCHIVE}}" >> .env.production
+        echo "GCS_PROXY_PARTITION=${{secrets.BULLENETWORK_CH_GCS_PROXY_PARTITION}}" >> .env.production
+        echo "GCS_PROXY_PARTITION_ARCHIVE=${{secrets.BULLENETWORK_CH_GCS_PROXY_PARTITION_ARCHIVE}}" >> .env.production
         echo "PARTITIONS_GRAPHQL_TOKEN=${{secrets.BULLENETWORK_CH_PARTITIONS_GRAPHQL_TOKEN}}" >> .env.production
-        echo "PARTITIONS_ENDPOINT=${{secrets.BULLENETWORK_CH_PARTITIONS_ENDPOINT}}" >> .env.production
         gatsby build
         
     - name: Sync

--- a/gcs-authenticator/controller.go
+++ b/gcs-authenticator/controller.go
@@ -1,0 +1,372 @@
+package main
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"golang.org/x/oauth2/jwt"
+	"golang.org/x/xerrors"
+)
+
+// controller defines the controller functions and holds common elements
+type controller struct {
+	jwtConf *jwt.Config
+	client  *storage.Client
+	log     *log.Logger
+	conf    configuration
+}
+
+// errorf prints the error and replies an HTTP error
+func (c controller) errorf(w http.ResponseWriter, code int, format string, v ...interface{}) {
+	msg := fmt.Sprintf(format, v...)
+	c.log.Printf("ERROR [%d]: %s", code, msg)
+	http.Error(w, msg, code)
+}
+
+// authPartition implements a POST endpoint that authenticates a file URL. It
+// takes as input an ID on a relation table, which allows to authenticate only a
+// subset of files.
+//
+// Expects:
+//   id=
+//
+func (c controller) auth(relationTable string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+		w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		if r.Method != http.MethodPost {
+			c.errorf(w, http.StatusMethodNotAllowed, "only POST allowed")
+			return
+		}
+
+		err := r.ParseForm()
+		if err != nil {
+			c.errorf(w, http.StatusInternalServerError, "failed to parse form: %v", err.Error())
+			return
+		}
+
+		id := r.Form.Get("id")
+		if id == "" {
+			c.errorf(w, http.StatusBadRequest, "id value not found")
+			return
+		}
+
+		c.log.Printf("got id: %s", id)
+
+		url := relationTable + id + "?access_token=" + c.conf.directusToken
+
+		object, err := getFile(url)
+		if err != nil {
+			c.errorf(w, http.StatusInternalServerError, "failed to get file: %v", err)
+			return
+		}
+
+		c.log.Printf("object: %s", object)
+
+		u, err := storage.SignedURL(c.conf.gcsBucketName, object, getOpts(c.jwtConf))
+		if err != nil {
+			c.errorf(w, http.StatusInternalServerError, "failed to create signed url: %v", err)
+			return
+		}
+
+		c.log.Printf("returning URL: %s", u)
+
+		fmt.Fprintf(w, "%s", u)
+	}
+}
+
+// getOpts get the Google Cloud Storage options based on the key file.
+func getOpts(conf *jwt.Config) *storage.SignedURLOptions {
+	return &storage.SignedURLOptions{
+		Scheme:         storage.SigningSchemeV4,
+		Method:         "GET",
+		GoogleAccessID: conf.Email,
+		PrivateKey:     conf.PrivateKey,
+		Expires:        time.Now().Add(validityPeriod),
+	}
+}
+
+// Returns the filename_disk from the relation table entry. The relation table
+// must be from any collection to the `items` collection, which then must
+// contain the `directus_files_id` attribute.
+func getFile(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", xerrors.Errorf("failed to get partition: %v", err)
+	}
+
+	type RelationResp struct {
+		Data struct {
+			DirectusFilesID string `json:"directus_files_id"`
+		} `json:"data"`
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+
+	var partition RelationResp
+
+	err = decoder.Decode(&partition)
+	if err != nil {
+		return "", xerrors.Errorf("failed to get response: %v", err)
+	}
+
+	url = directusFileURL + partition.Data.DirectusFilesID
+
+	resp, err = http.Get(url)
+	if err != nil {
+		return "", xerrors.Errorf("failed to get file: %v", err)
+	}
+
+	type FileResp struct {
+		Data struct {
+			FilenameDisk string `json:"filename_disk"`
+		} `json:"data"`
+	}
+
+	decoder = json.NewDecoder(resp.Body)
+
+	var file FileResp
+
+	err = decoder.Decode(&file)
+	if err != nil {
+		return "", xerrors.Errorf("failed to decode file: %v", err)
+	}
+
+	return file.Data.FilenameDisk, nil
+}
+
+// archive implements POST /archive. This endpoint creates an uncompressed ZIP
+// file containing all the requested files. It expects argument as post form
+// parameter:
+//
+// "bucket" => BUCKET_NAME,
+// ID_1 => FILENAME_1
+// ID_2 => FILENAME_2
+// ...
+//
+// The ID must be an ID from the relation table.
+//
+func (c controller) archive(relationTable string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, ok := w.(http.Flusher)
+		if !ok {
+			c.errorf(w, http.StatusInternalServerError, "flusher not supported")
+			return
+		}
+
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+		w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		if r.Method != http.MethodPost {
+			c.errorf(w, http.StatusMethodNotAllowed, "only POST allowed")
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/zip")
+		w.Header().Set("Content-Disposition", "attachment; filename=\"bullenetwork.zip\"")
+
+		err := r.ParseForm()
+		if err != nil {
+			c.errorf(w, http.StatusInternalServerError, "failed to parse form: %v", err)
+			return
+		}
+
+		bucket := r.Form.Get("bucket")
+		if bucket == "" {
+			c.errorf(w, http.StatusBadRequest, "bucket value not found")
+			return
+		}
+
+		type fileRequest struct {
+			Name   string
+			Object string
+		}
+
+		objects := []fileRequest{}
+
+		// k: ID of the relation table entry, which must contain an
+		//    `directus_files_id` attribute.
+		// v[0]: filename
+		for k, v := range r.Form {
+			if k == "bucket" {
+				continue
+			}
+
+			if len(v) != 1 {
+				continue
+			}
+
+			url := relationTable + k + "?access_token=" + c.conf.directusToken
+
+			c.log.Printf("archive: getting file: %s", url)
+
+			object, err := getFile(url)
+			if err != nil {
+				c.errorf(w, http.StatusInternalServerError, "failed to get file: %v", err)
+				return
+			}
+
+			objects = append(objects, fileRequest{
+				Name:   v[0],
+				Object: object,
+			})
+		}
+
+		zipWriter := zip.NewWriter(w)
+		defer zipWriter.Close()
+
+		for _, fileRequest := range objects {
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*50)
+			defer cancel()
+
+			rc, err := c.client.Bucket(bucket).Object(fileRequest.Object).NewReader(ctx)
+			if err != nil {
+				c.errorf(w, http.StatusInternalServerError, "failed to get object: %v", err)
+				return
+			}
+
+			defer rc.Close()
+
+			header := zip.FileHeader{
+				Name:     fileRequest.Name,
+				Method:   zip.Store,
+				Modified: time.Now(),
+			}
+
+			writer, err := zipWriter.CreateHeader(&header)
+			if err != nil {
+				c.errorf(w, http.StatusInternalServerError, "failed to create header: %v", err)
+				return
+			}
+
+			_, err = io.Copy(writer, rc)
+			if err != nil {
+				c.errorf(w, http.StatusInternalServerError, "failed to copy: %v", err)
+				return
+			}
+
+			zipWriter.Flush()
+			w.(http.Flusher).Flush()
+		}
+	}
+}
+
+// gcspub returns a HTTP handler that updates the ACL to make an object public.
+// It expects a hook message from directus. The object is updated only if the
+// updated element (i.e. directus field) is named "image".
+func (c controller) gcspub() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		type accountability struct {
+			User string `json:"user"`
+			Role string `json:"role"`
+		}
+
+		type hook struct {
+			Event          string          `json:"event"`
+			Accountability accountability  `json:"accountability"`
+			Payload        json.RawMessage `json:"payload"`
+			Collection     string          `json:"collection"`
+		}
+
+		var h hook
+
+		err := json.NewDecoder(r.Body).Decode(&h)
+		if err != nil {
+			c.errorf(w, http.StatusBadRequest, "failed to unmarshal hook: %v", err)
+			return
+		}
+
+		type image struct {
+			Image string `json:"image"`
+		}
+
+		var m image
+
+		err = json.Unmarshal(h.Payload, &m)
+		if err != nil {
+			c.errorf(w, http.StatusBadRequest, "failed to unmarshal image: %v", err)
+			return
+		}
+
+		object := m.Image
+		if object == "" {
+			return
+		}
+
+		filenameDisk, err := getDirectusFilename(object)
+		if err != nil {
+			c.errorf(w, http.StatusInternalServerError, "failed to get filename_disk: %v", err)
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		defer cancel()
+
+		acl := c.client.Bucket(c.conf.gcsBucketName).Object(filenameDisk).ACL()
+
+		err = acl.Set(ctx, storage.AllUsers, storage.RoleReader)
+		if err != nil {
+			c.errorf(w, http.StatusInternalServerError, "failed to set ACL: %v", err)
+			return
+		}
+	}
+}
+
+// getDirectusFilename returns the filename_disk attribute of a Directus file
+func getDirectusFilename(object string) (string, error) {
+	res, err := http.Get(directusFileURL + object)
+	if err != nil {
+		return "", xerrors.Errorf("failed to get Directus image: %v", err)
+	}
+
+	var objmap map[string]json.RawMessage
+
+	err = json.NewDecoder(res.Body).Decode(&objmap)
+	if err != nil {
+		return "", xerrors.Errorf("failed to decode response: %v", err)
+	}
+
+	data := objmap["data"]
+	if len(data) == 0 {
+		return "", xerrors.Errorf("data empty: %v", objmap)
+	}
+
+	type attributes struct {
+		FilenameDisk string `json:"filename_disk"`
+	}
+
+	var attr attributes
+
+	err = json.Unmarshal(data, &attr)
+	if err != nil {
+		return "", xerrors.Errorf("failed to unmarshal data: %v", err)
+	}
+
+	if attr.FilenameDisk == "" {
+		return "", xerrors.Errorf("filename_disk empty: %v", objmap)
+	}
+
+	return attr.FilenameDisk, nil
+}

--- a/gcs-authenticator/mod.go
+++ b/gcs-authenticator/mod.go
@@ -13,12 +13,9 @@
 package main
 
 import (
-	"archive/zip"
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"net"
@@ -30,19 +27,23 @@ import (
 	"google.golang.org/api/option"
 
 	"golang.org/x/oauth2/google"
-	"golang.org/x/oauth2/jwt"
 	"golang.org/x/xerrors"
 )
 
 const validityPeriod = time.Minute * 10
 const defaultAddr = ":9990"
 
-const GCS_KEY_PATH = "GCS_PRIVATE_PATH"
-const BUCKET_KEY_NAME = "GCS_BUCKET_NAME"
-const DIRECTUS_TOKEN_KEY = "DIRECTUS_TOKEN"
+// defines the OS env keys that must be provided
+const (
+	KEY_GCS_PATH       = "GCS_PRIVATE_PATH"
+	KEY_BUCKET_NAME    = "GCS_BUCKET_NAME"
+	KEY_DIRECTUS_TOKEN = "DIRECTUS_TOKEN"
+)
 
 const directusFileURL = "https://truite.bullenetwork.ch/files/"
-const directusPartitionsFilesURL = "https://truite.bullenetwork.ch/items/partitions_directus_files_2/"
+
+const partitionRelationTable = "https://truite.bullenetwork.ch/items/partitions_directus_files_2/"
+const mediasRelationTable = "https://truite.bullenetwork.ch/items/Medias_files/"
 
 type key int
 
@@ -50,386 +51,56 @@ const (
 	requestIDKey key = 0
 )
 
+// configuration defines the input configurations
+type configuration struct {
+	gcsKeyPath    string
+	gcsBucketName string
+	directusToken string
+}
+
 func main() {
 	var listenAddr string
 	flag.StringVar(&listenAddr, "listen-addr", defaultAddr, "server listen address")
 	flag.Parse()
 
-	logger := log.New(os.Stdout, "http: ", log.LstdFlags)
-
-	gcs_key_path := os.Getenv(GCS_KEY_PATH)
-	if gcs_key_path == "" {
-		logger.Fatalf("please set %s", GCS_KEY_PATH)
-	}
-
-	gcs_bucket_name := os.Getenv(BUCKET_KEY_NAME)
-	if gcs_bucket_name == "" {
-		logger.Fatalf("please set %s", BUCKET_KEY_NAME)
-	}
-
-	directus_token := os.Getenv(DIRECTUS_TOKEN_KEY)
-	if directus_token == "" {
-		logger.Fatalf("please set %s", DIRECTUS_TOKEN_KEY)
-	}
-
-	jsonKey, err := ioutil.ReadFile(gcs_key_path)
+	conf, err := getConfiguration()
 	if err != nil {
-		logger.Fatalf("failed to read key: %v", err.Error())
+		log.Fatalf("failed to get configuration: %v", err)
 	}
 
-	conf, err := google.JWTConfigFromJSON(jsonKey)
+	ctrl, err := getController(conf)
 	if err != nil {
-		logger.Fatalf("failed to read config: %v", err.Error())
+		log.Fatalf("failed to get controller: %v", err)
 	}
 
-	client, err := storage.NewClient(context.Background(), option.WithCredentialsFile(gcs_key_path))
-	if err != nil {
-		logger.Fatalf("failed to creat client: %v", err)
-	}
-
-	defer client.Close()
+	defer ctrl.client.Close()
 
 	mux := http.NewServeMux()
 	server := &http.Server{
-		Handler:  tracing(nextRequestID)(logging(logger)(mux)),
-		ErrorLog: logger,
+		Handler:  tracing(nextRequestID)(logging(ctrl.log)(mux)),
+		ErrorLog: ctrl.log,
 	}
 
-	mux.HandleFunc("/auth/partition", authPartition(conf, gcs_bucket_name, directus_token))
-	mux.HandleFunc("/archive", archive(client))
-	mux.HandleFunc("/gcspub", gcspub(client, gcs_bucket_name))
+	mux.HandleFunc("/partitions/auth", ctrl.auth(partitionRelationTable))
+	mux.HandleFunc("/partitions/archive", ctrl.archive(partitionRelationTable))
+
+	mux.HandleFunc("/medias/auth", ctrl.auth(mediasRelationTable))
+	mux.HandleFunc("/medias/archive", ctrl.archive(mediasRelationTable))
+
+	mux.HandleFunc("/gcspub", ctrl.gcspub())
 
 	ln, err := net.Listen("tcp", listenAddr)
 	if err != nil {
-		logger.Fatalf("failed to create conn '%s': %v", listenAddr, err)
+		ctrl.log.Fatalf("failed to create conn '%s': %v", listenAddr, err)
 		return
 	}
 
-	logger.Printf("Server is ready to handle request at %s", ln.Addr())
+	ctrl.log.Printf("Server is ready to handle request at %s", ln.Addr())
 
 	err = server.Serve(ln)
 	if err != nil && err != http.ErrServerClosed {
-		logger.Fatal(err)
+		ctrl.log.Fatal(err)
 	}
-}
-
-// getOpts get the Google Cloud Storage options based on the key file.
-func getOpts(conf *jwt.Config) *storage.SignedURLOptions {
-	return &storage.SignedURLOptions{
-		Scheme:         storage.SigningSchemeV4,
-		Method:         "GET",
-		GoogleAccessID: conf.Email,
-		PrivateKey:     conf.PrivateKey,
-		Expires:        time.Now().Add(validityPeriod),
-	}
-}
-
-// authPartition implements POST /auth/partition
-// expects:
-//   id=
-func authPartition(conf *jwt.Config, bucket, token string) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
-		w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
-
-		if r.Method == "OPTIONS" {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-
-		if r.Method != http.MethodPost {
-			http.Error(w, "only POST allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		err := r.ParseForm()
-		if err != nil {
-			http.Error(w, "failed to parse form: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		id := r.Form.Get("id")
-		if id == "" {
-			http.Error(w, "id value not found", http.StatusBadRequest)
-			return
-		}
-
-		object, err := getFile(id, token)
-		if err != nil {
-			http.Error(w, "failed to get file: "+err.Error(), http.StatusInternalServerError)
-		}
-
-		u, err := storage.SignedURL(bucket, object, getOpts(conf))
-		if err != nil {
-			http.Error(w, "failed to create signed url: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		fmt.Fprintf(w, "%s", u)
-	}
-}
-
-// Returns the filename_disk from the partition relation table
-func getFile(id, token string) (string, error) {
-	url := directusPartitionsFilesURL + id + "access_token=" + token
-
-	resp, err := http.Get(url)
-	if err != nil {
-		return "", xerrors.Errorf("failed to get partition: %v", err)
-	}
-
-	type PartitionResp struct {
-		Data struct {
-			ID              int    `json:"id"`
-			PartitionsID    string `json:"partitions_id"`
-			DirectusFilesID string `json:"directus_files_id"`
-		} `json:"data"`
-	}
-
-	decoder := json.NewDecoder(resp.Body)
-
-	var partition PartitionResp
-
-	err = decoder.Decode(&partition)
-	if err != nil {
-		return "", xerrors.Errorf("failed to get response: %v", err)
-	}
-
-	url = directusFileURL + partition.Data.DirectusFilesID
-
-	resp, err = http.Get(url)
-	if err != nil {
-		return "", xerrors.Errorf("failed to get file: %v", err)
-	}
-
-	type FileResp struct {
-		Data struct {
-			FilenameDisk string `json:"filename_disk"`
-		} `json:"data"`
-	}
-
-	decoder = json.NewDecoder(resp.Body)
-
-	var file FileResp
-
-	err = decoder.Decode(&file)
-	if err != nil {
-		return "", xerrors.Errorf("failed to decode file: %v", err)
-	}
-
-	return file.Data.FilenameDisk, nil
-}
-
-// archive implements POST /archive. This endpoint creates an uncompressed ZIP
-// file containing all the requested files. It expects argument as post form
-// parameter:
-//
-// "bucket" => BUCKET_NAME,
-// OBJECT_PATH_1 => FILENAME_1
-// OBJECT_PATH_2 => FILENAME_2
-// ...
-//
-func archive(client *storage.Client) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		_, ok := w.(http.Flusher)
-		if !ok {
-			http.Error(w, "flusher not supported", http.StatusInternalServerError)
-			return
-		}
-
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
-		w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
-
-		if r.Method == "OPTIONS" {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-
-		if r.Method != http.MethodPost {
-			http.Error(w, "only POST allowed", http.StatusMethodNotAllowed)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/zip")
-		w.Header().Set("Content-Disposition", "attachment; filename=\"partitions.zip\"")
-
-		err := r.ParseForm()
-		if err != nil {
-			http.Error(w, "failed to parse form: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		bucket := r.Form.Get("bucket")
-		if bucket == "" {
-			http.Error(w, "bucket value not found", http.StatusBadRequest)
-			return
-		}
-
-		type fileRequest struct {
-			Name   string
-			Object string
-		}
-
-		objects := []fileRequest{}
-
-		for k, v := range r.Form {
-			if k == "bucket" {
-				continue
-			}
-
-			objects = append(objects, fileRequest{
-				Name:   v[0],
-				Object: k,
-			})
-		}
-
-		zipWriter := zip.NewWriter(w)
-		defer zipWriter.Close()
-
-		for _, fileRequest := range objects {
-
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*50)
-			defer cancel()
-
-			rc, err := client.Bucket(bucket).Object(fileRequest.Object).NewReader(ctx)
-			if err != nil {
-				http.Error(w, "failed to get object: "+err.Error(), http.StatusInternalServerError)
-				return
-			}
-
-			defer rc.Close()
-
-			header := zip.FileHeader{
-				Name:     fileRequest.Name,
-				Method:   zip.Store,
-				Modified: time.Now(),
-			}
-
-			writer, err := zipWriter.CreateHeader(&header)
-			if err != nil {
-				http.Error(w, "failed to create header: "+err.Error(), http.StatusInternalServerError)
-			}
-
-			_, err = io.Copy(writer, rc)
-			if err != nil {
-				http.Error(w, "failed to copy: "+err.Error(), http.StatusInternalServerError)
-			}
-
-			zipWriter.Flush()
-			w.(http.Flusher).Flush()
-		}
-	}
-}
-
-// gcspub returns a HTTP handler that updates the ACL to make an object public.
-// It expects a hook message from directus. The object is updated only if the
-// updated element (i.e. directus field) is named "image".
-func gcspub(client *storage.Client, bucket string) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-
-		type accountability struct {
-			User string `json:"user"`
-			Role string `json:"role"`
-		}
-
-		type hook struct {
-			Event          string          `json:"event"`
-			Accountability accountability  `json:"accountability"`
-			Payload        json.RawMessage `json:"payload"`
-			Collection     string          `json:"collection"`
-		}
-
-		var h hook
-
-		err := json.NewDecoder(r.Body).Decode(&h)
-		if err != nil {
-			err = xerrors.Errorf("failed to unmarshal hook: %v", err)
-			fmt.Println("error:", err)
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		type image struct {
-			Image string `json:"image"`
-		}
-
-		var m image
-
-		err = json.Unmarshal(h.Payload, &m)
-		if err != nil {
-			err = xerrors.Errorf("failed to unmarshal image: %v", err)
-			fmt.Println("error:", err)
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-
-		object := m.Image
-		if object == "" {
-			return
-		}
-
-		filenameDisk, err := getDirectusFilename(object)
-		if err != nil {
-			err = xerrors.Errorf("failed to get filename_disk: %v", err.Error())
-			fmt.Println("error:", err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-		defer cancel()
-
-		acl := client.Bucket(bucket).Object(filenameDisk).ACL()
-
-		err = acl.Set(ctx, storage.AllUsers, storage.RoleReader)
-		if err != nil {
-			err = xerrors.Errorf("failed to set acl: %v", err)
-			fmt.Println("error:", err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	}
-}
-
-// getDirectusFilename returns the filename_disk attribute of a Directus file
-func getDirectusFilename(object string) (string, error) {
-	res, err := http.Get(directusFileURL + object)
-	if err != nil {
-		return "", xerrors.Errorf("failed to get Directus image: %v", err)
-	}
-
-	var objmap map[string]json.RawMessage
-
-	err = json.NewDecoder(res.Body).Decode(&objmap)
-	if err != nil {
-		return "", xerrors.Errorf("failed to decode response: %v", err)
-	}
-
-	data := objmap["data"]
-	if len(data) == 0 {
-		return "", xerrors.Errorf("data empty: %v", objmap)
-	}
-
-	type attributes struct {
-		FilenameDisk string `json:"filename_disk"`
-	}
-
-	var attr attributes
-
-	err = json.Unmarshal(data, &attr)
-	if err != nil {
-		return "", xerrors.Errorf("failed to unmarshal data: %v", err)
-	}
-
-	if attr.FilenameDisk == "" {
-		return "", xerrors.Errorf("filename_disk empty: %v", objmap)
-	}
-
-	fmt.Println("filename disk:", attr.FilenameDisk)
-
-	return attr.FilenameDisk, nil
 }
 
 func nextRequestID() string {
@@ -463,4 +134,54 @@ func tracing(nextRequestID func() string) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+func getConfiguration() (configuration, error) {
+	gcsKeyPath := os.Getenv(KEY_GCS_PATH)
+	if gcsKeyPath == "" {
+		return configuration{}, xerrors.Errorf("please set %s", KEY_GCS_PATH)
+	}
+
+	gcsBucketName := os.Getenv(KEY_BUCKET_NAME)
+	if gcsBucketName == "" {
+		return configuration{}, xerrors.Errorf("please set %s", KEY_BUCKET_NAME)
+	}
+
+	directusToken := os.Getenv(KEY_DIRECTUS_TOKEN)
+	if directusToken == "" {
+		return configuration{}, xerrors.Errorf("please set %s", KEY_DIRECTUS_TOKEN)
+	}
+
+	return configuration{
+		gcsKeyPath:    gcsKeyPath,
+		gcsBucketName: gcsBucketName,
+		directusToken: directusToken,
+	}, nil
+}
+
+func getController(conf configuration) (controller, error) {
+	jsonKey, err := ioutil.ReadFile(conf.gcsKeyPath)
+	if err != nil {
+		return controller{}, xerrors.Errorf("failed to read key: %v", err.Error())
+	}
+
+	jwtConf, err := google.JWTConfigFromJSON(jsonKey)
+	if err != nil {
+		return controller{}, xerrors.Errorf("failed to read config: %v", err.Error())
+	}
+
+	client, err := storage.NewClient(context.Background(),
+		option.WithCredentialsFile(conf.gcsKeyPath))
+	if err != nil {
+		return controller{}, xerrors.Errorf("failed to creat client: %v", err)
+	}
+
+	logger := log.New(os.Stdout, "http: ", log.LstdFlags)
+
+	return controller{
+		jwtConf: jwtConf,
+		conf:    conf,
+		client:  client,
+		log:     logger,
+	}, nil
 }


### PR DESCRIPTION
Instead of authenticating all URLs, the endpoints now checks the file from a relation table. This allow to have specific endpoints for different collections.