### PR TITLE
Adds a retry mechanism when the token expires

### DIFF
--- a/bullenetwork.ch/src/components/media.js
+++ b/bullenetwork.ch/src/components/media.js
@@ -124,52 +124,67 @@ const File = ({ file, notify }) => {
     // this makes the trick to not being blocked as a popup in safari
     // https://stackoverflow.com/a/39387533
     var windowReference = window.open();
-    windowReference.document.body.innerHTML = `<div style="text-align:center;padding-top:10%;font-size:14px;">chargement...</div>`;
+
+    const loadingMsg = `<div style="text-align:center;padding-top:10%;font-size:14px;">chargement...</div>`
+    const refreshingMsg = `<div style="text-align:center;padding-top:10%;font-size:14px;">rafraîchissement du jeton d'authentification...</div>`
+
+    windowReference.document.body.innerHTML = loadingMsg;
 
     const fileID = file.directus_files_id.id;
-    const body = `id=${fileID}&access_token=${accessToken}`;
 
-    fetch(process.env.GATSBY_GCS_AUTH_ENDPOINT, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded"
-      },
-      body: body
-    }).then(res => {
-      if (!res.ok) {
-        windowReference.close();
-
-        res.json().then((resp) => {
-          // 10 means the auth service got a Directus error
-          if (resp.error.code === 10) {
-            handleError(resp.error.data)
-            setLink("");
-          } else {
-            setLink(resp.error.message);
-          }
-        }).catch((e) => {
-          setLink(`error: ${res.statusText} - ${e}`)
-        })
-        return
-      }
-      res.text().then((t) => {
-        if (!res.ok) {
-          windowReference.close();
-          setLink(`error: ${t}`);
-        } else {
-          windowReference.location = t;
-          setLink(<a href={t} rel="noopener noreferrer" target="_blank">{filename}</a>)
-
-          setTimeout(function () {
-            setLink("");
-            // the url expires after 10 minutes, we wait 10 minutes - 10 seconds
-          }, (10 * 60 - 10) * 1000);
-        }
-      })
-    }).catch((e) => {
-      setLink(`error: ${e}`)
+    const onDone = () => {
       windowReference.close();
-    })
+    }
+
+    const fetchMedia = (token, retryFn) => {
+      const body = `id=${fileID}&access_token=${token}`;
+
+      fetch(process.env.GATSBY_GCS_AUTH_ENDPOINT, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded"
+        },
+        body: body
+      }).then(res => {
+        if (!res.ok) {
+          res.json().then((resp) => {
+            // 10 means the auth service got a Directus error
+            if (resp.error.code === 10) {
+              windowReference.document.body.innerHTML = refreshingMsg;
+              handleError(resp.error.data, retryFn, onDone)
+              setLink("");
+            } else {
+              setLink(resp.error.message);
+            }
+          }).catch((e) => {
+            onDone();
+            setLink(`error: ${res.statusText} - ${e}`)
+          })
+          return
+        }
+        res.text().then((t) => {
+          if (!res.ok) {
+            windowReference.close();
+            setLink(`error: ${t}`);
+          } else {
+            windowReference.location = t;
+            setLink(<a href={t} rel="noopener noreferrer" target="_blank">{filename}</a>)
+
+            setTimeout(function () {
+              setLink("");
+              // the url expires after 10 minutes, we wait 10 minutes - 10 seconds
+            }, (10 * 60 - 10) * 1000);
+          }
+        })
+      }).catch((e) => {
+        setLink(`error: ${e}`)
+        windowReference.close();
+      })
+    }
+
+    const failover = (newToken) => { onDone() } // called when the retry fails
+    const retryFn = (newToken) => { fetchMedia(newToken, failover) } // called when retry
+    fetchMedia(accessToken, retryFn)
   }
 
   const [link, setLink] = useState("");

--- a/bullenetwork.ch/src/components/securedirectus.js
+++ b/bullenetwork.ch/src/components/securedirectus.js
@@ -31,9 +31,9 @@ export const SecureDirectus = ({ children, email, className }) => {
     }
   }, [accessToken])
 
-  const handleError = (response) => {
-
+  const handleError = (response, onRetry, onDone) => {
     if (response.errors.length === 0) {
+      onDone();
       setError("Empty error, please login.");
       setShowLogin(true);
       return
@@ -43,6 +43,7 @@ export const SecureDirectus = ({ children, email, className }) => {
       const auth_info = JSON.parse(window.localStorage.getItem(key));
 
       if (!auth_info) {
+        onDone();
         setError("Please login.")
         setShowLogin(true);
         return
@@ -62,15 +63,19 @@ export const SecureDirectus = ({ children, email, className }) => {
           } else if (resp.data) {
             localStorage.setItem(key, JSON.stringify([resp.data]));
             setAccessToken(resp.data.access_token);
+            console.log("set access token:", resp.data.access_token)
+            onRetry(resp.data.access_token);
           } else {
             throw "bad response:" + JSON.stringify(resp);
           }
         }).catch((e) => {
+          onDone();
           setError(e);
           setShowLogin(true);
           return null
         })
     } else {
+      onDone();
       setError("Erreur de login: " + response.errors[0].message);
       setShowLogin(true);
     }

--- a/bullenetwork.ch/src/pages/medias.js
+++ b/bullenetwork.ch/src/pages/medias.js
@@ -66,7 +66,7 @@ const Medias = () => {
       return req.json();
     }).then((response) => {
       if (response.errors) {
-        handleError(response)
+        handleError(response, () => { }, () => { })
       } else {
         setRawdata(response.data.medias)
       }
@@ -175,7 +175,7 @@ const Medias = () => {
           res.json().then((resp) => {
             // 10 means the auth service got a Directus error
             if (resp.error.code === 10) {
-              handleError(resp.error.data)
+              handleError(resp.error.data, () => { }, () => { })
               setArchiveInfo("");
             } else {
               setArchiveInfo(resp.error.message);

--- a/bullenetwork.ch/src/pages/partitions.js
+++ b/bullenetwork.ch/src/pages/partitions.js
@@ -67,7 +67,7 @@ export const Partitions = () => {
       return req.json();
     }).then((response) => {
       if (response.errors) {
-        handleError(response)
+        handleError(response, () => { }, () => { })
       } else {
         setRawdata(response.data.partitions)
       }
@@ -201,7 +201,7 @@ export const Partitions = () => {
           res.json().then((resp) => {
             // 10 means the auth service got a Directus error
             if (resp.error.code === 10) {
-              handleError(resp.error.data)
+              handleError(resp.error.data, () => { }, () => { })
               setArchiveInfo("");
             } else {
               setArchiveInfo(resp.error.message);


### PR DESCRIPTION
Previously when the token expired the user had to do the action again. Now when the token expires and is refreshed, the action that triggered the refresh is retried.

This is done with two new callback functions that must be provided to the function that refreshes the token: `onRetry` and `onDone`. `onRetry` is called when the token was successfully refreshed, and `onDone` when something unexpected happened. 